### PR TITLE
Load env variables before binding

### DIFF
--- a/src/main/java/com/example/matchapp/CreateIaProfilesApplication.java
+++ b/src/main/java/com/example/matchapp/CreateIaProfilesApplication.java
@@ -1,30 +1,22 @@
 package com.example.matchapp;
 
-import com.example.matchapp.config.EnvFileLoader;
 import com.example.matchapp.config.ImageGenProperties;
 import com.example.matchapp.service.ProfileService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 import java.nio.file.Paths;
-import java.util.Map;
 
 @SpringBootApplication(scanBasePackages = {"com.example.matchapp"})
 @EnableConfigurationProperties(ImageGenProperties.class)
 public class CreateIaProfilesApplication implements CommandLineRunner {
 
-    private static final Logger logger = LoggerFactory.getLogger(CreateIaProfilesApplication.class);
-
     private final ProfileService profileService;
-    private final EnvFileLoader envFileLoader;
 
-    public CreateIaProfilesApplication(ProfileService profileService, EnvFileLoader envFileLoader) {
+    public CreateIaProfilesApplication(ProfileService profileService) {
         this.profileService = profileService;
-        this.envFileLoader = envFileLoader;
     }
 
     public static void main(String[] args) {
@@ -33,25 +25,6 @@ public class CreateIaProfilesApplication implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        // Load environment variables from .env file
-        Map<String, String> envVars = envFileLoader.loadEnvFile();
-
-        // Check if the API key is missing or using the default placeholder
-        String apiKey = envVars.get("OPENAI_API_KEY");
-        if (apiKey == null || apiKey.isEmpty() || "your_openai_key_here".equals(apiKey)) {
-            logger.error("OPENAI_API_KEY environment variable is not set or is using the default placeholder value.");
-            logger.error("The application will likely fail with a 401 Unauthorized error when trying to use the OpenAI API.");
-            logger.error("Please follow these steps to set up your OpenAI API key:");
-            logger.error("1. Go to https://platform.openai.com/api-keys to create an API key if you don't have one");
-            logger.error("2. Copy your API key from the OpenAI dashboard");
-            logger.error("3. Open the .env file in the project root directory");
-            logger.error("4. Replace 'your_openai_key_here' with your actual API key");
-            logger.error("5. Save the file and restart the application");
-
-            // We'll still run the application, but it will likely fail with a more specific error message
-            // from the OpenAIImageGenerationService
-        }
-
         profileService.generateImages(Paths.get("src/main/resources/static/images"));
     }
 }

--- a/src/main/java/com/example/matchapp/config/EnvFileLoader.java
+++ b/src/main/java/com/example/matchapp/config/EnvFileLoader.java
@@ -23,6 +23,11 @@ public class EnvFileLoader {
     private static final String ENV_FILE_PATH = ".env";
     private static final Pattern ENV_ENTRY_PATTERN = Pattern.compile("^\\s*([\\w.-]+)\\s*=\\s*(.*)\\s*$");
 
+    @jakarta.annotation.PostConstruct
+    public void init() {
+        loadEnvFile();
+    }
+
     /**
      * Loads environment variables from the .env file.
      * If the file doesn't exist, it creates one with default values.

--- a/src/test/java/com/example/matchapp/config/EnvFileLoaderIntegrationTest.java
+++ b/src/test/java/com/example/matchapp/config/EnvFileLoaderIntegrationTest.java
@@ -1,0 +1,48 @@
+package com.example.matchapp.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnvFileLoaderIntegrationTest {
+
+    @Configuration
+    @EnableConfigurationProperties(ImageGenProperties.class)
+    static class TestConfig {
+        @Bean
+        EnvFileLoader envFileLoader() {
+            return new EnvFileLoader();
+        }
+    }
+
+    @TempDir
+    Path tempDir;
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(TestConfig.class);
+
+    @Test
+    void propertiesLoadedFromEnvFile() throws Exception {
+        Path env = tempDir.resolve(".env");
+        Files.writeString(env, "OPENAI_API_KEY=test-key\nOPENAI_BASE_URL=https://example.com\n");
+        String originalUserDir = System.getProperty("user.dir");
+        System.setProperty("user.dir", tempDir.toString());
+        try {
+            contextRunner.run(context -> {
+                ImageGenProperties props = context.getBean(ImageGenProperties.class);
+                assertEquals("test-key", props.getApiKey());
+                assertEquals("https://example.com", props.getBaseUrl());
+            });
+        } finally {
+            System.setProperty("user.dir", originalUserDir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- load environment variables via `@PostConstruct` in `EnvFileLoader`
- simplify `CreateIaProfilesApplication` to rely on automatic environment loading
- add integration test checking that `ImageGenProperties` receives values from `.env`

## Testing
- `./mvnw -q -o test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6842f97b28d4832e8ea67ec027b83dce