### PR TITLE
Add model parameter to OpenAI requests

### DIFF
--- a/src/main/java/com/example/matchapp/service/impl/OpenAIImageGenerationService.java
+++ b/src/main/java/com/example/matchapp/service/impl/OpenAIImageGenerationService.java
@@ -36,17 +36,26 @@ public class OpenAIImageGenerationService implements ImageGenerationService {
                 .build();
     }
 
+    /**
+     * Builds the request body for the OpenAI image generation API.
+     * Exposed as a protected method to allow inspection in tests.
+     */
+    protected Map<String, Object> createRequest(Profile profile) {
+        return Map.of(
+                "prompt", profile.bio(),
+                "n", 1,
+                "size", "1024x1024",
+                "response_format", "b64_json",
+                "model", "dall-e-3"
+        );
+    }
+
     @Override
     public byte[] generateImage(Profile profile) {
         MDC.put("profileId", profile.id());
         try {
             logger.info("Requesting image generation");
-            Map<String, Object> request = Map.of(
-                    "prompt", profile.bio(),
-                    "n", 1,
-                    "size", "1024x1024",
-                    "response_format", "b64_json"
-            );
+            Map<String, Object> request = createRequest(profile);
 
             try {
                 // This call returns JSON with base64 image.

--- a/src/test/java/com/example/matchapp/service/impl/OpenAIImageGenerationServiceTest.java
+++ b/src/test/java/com/example/matchapp/service/impl/OpenAIImageGenerationServiceTest.java
@@ -1,0 +1,60 @@
+package com.example.matchapp.service.impl;
+
+import com.example.matchapp.config.ImageGenProperties;
+import com.example.matchapp.model.Profile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OpenAIImageGenerationServiceTest {
+
+    private static class TestOpenAIImageGenerationService extends OpenAIImageGenerationService {
+        private Map<String, Object> capturedRequest;
+
+        TestOpenAIImageGenerationService(ImageGenProperties properties) {
+            super(properties);
+        }
+
+        @Override
+        public byte[] generateImage(Profile profile) {
+            capturedRequest = createRequest(profile);
+            return new byte[] {1, 2, 3};
+        }
+
+        Map<String, Object> getCapturedRequest() {
+            return capturedRequest;
+        }
+    }
+
+    private TestOpenAIImageGenerationService service;
+
+    @BeforeEach
+    void setUp() {
+        ImageGenProperties props = new ImageGenProperties();
+        props.setApiKey("test-key");
+        props.setBaseUrl("https://api.openai.com");
+        service = new TestOpenAIImageGenerationService(props);
+    }
+
+    @Test
+    void generateImage_includesModelField() {
+        Profile profile = new Profile(
+                "id",
+                "First",
+                "Last",
+                30,
+                "Ethnicity",
+                "MALE",
+                "Sample bio",
+                "img.jpg",
+                "INTJ"
+        );
+
+        service.generateImage(profile);
+        Map<String, Object> request = service.getCapturedRequest();
+        assertEquals("dall-e-3", request.get("model"));
+    }
+}


### PR DESCRIPTION
## Summary
- include `model` in OpenAI request map
- expose request creation for testing
- add unit test for `OpenAIImageGenerationService`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6842f98356a4832eb662ee91109ad1fe