### PR TITLE
Update SpotBugs plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.7.3.0</version>
+                <version>4.8.6.0</version>
                 <configuration>
                     <effort>Max</effort>
                     <threshold>Medium</threshold>


### PR DESCRIPTION
## Summary
- update `spotbugs-maven-plugin` to a newer version

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684496983f5c832e97b64bbeba84556f