### PR TITLE
Disable OpenAI services in tests

### DIFF
--- a/src/main/java/com/example/matchapp/service/impl/OpenAIImageGenerationService.java
+++ b/src/main/java/com/example/matchapp/service/impl/OpenAIImageGenerationService.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Service
+@org.springframework.context.annotation.Profile("!test")
 public class OpenAIImageGenerationService extends AbstractImageGenerationService {
 
     private static final Logger logger = LoggerFactory.getLogger(OpenAIImageGenerationService.class);

--- a/src/main/java/com/example/matchapp/service/impl/SpringAIImageGenerationService.java
+++ b/src/main/java/com/example/matchapp/service/impl/SpringAIImageGenerationService.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 @Service
 @Primary
+@org.springframework.context.annotation.Profile("!test")
 public class SpringAIImageGenerationService extends AbstractImageGenerationService {
 
     private static final Logger logger = LoggerFactory.getLogger(SpringAIImageGenerationService.class);


### PR DESCRIPTION
## Summary
- avoid loading OpenAIImageGenerationService and SpringAIImageGenerationService when the **test** profile is active

## Testing
- `./scripts/run_tests_offline.sh` *(fails: Non-resolvable parent POM)*
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6845d35f3908832e8739ceb7c313a35a